### PR TITLE
fix(fetch): Mark git repo as safe

### DIFF
--- a/packs/fetch/build/init.sh
+++ b/packs/fetch/build/init.sh
@@ -31,6 +31,7 @@ echo "Done"
 
 echo "========== Clone Repository from $GIT_REPOSITORY"
 cd /app
+git config --global --add safe.directory /app #Mark git directory as safe
 git clone --recurse-submodules $GIT_REPOSITORY .
 git checkout $GIT_BRANCH
 rm -rf .git


### PR DESCRIPTION
Hi,

I noticed that git complained about the repo found in /app with the following error:
```bash
fatal: detected dubious ownership in repository at '/app'
To add an exception for this directory, call:

        git config --global --add safe.directory /app
```

This prevented the git checkout from actually working -  therefor not allowing builds from the branches selected via the UI and/or CRD.
This is pretty much the quick and dirty fix.