### PR TITLE
make sure init.sh exit on error

### DIFF
--- a/packs/fetch/build/init.sh
+++ b/packs/fetch/build/init.sh
@@ -28,7 +28,7 @@ touch ~/.ssh/known_hosts
 chmod -v 644 ~/.ssh/known_hosts
 
 echo "========== whipe the app dir"
-rm -rf /app/* /app/.* >> /dev/null 2>&1
+rm -rf /app/* /app/.* >> /dev/null 2>&1 || true
 echo "Done"
 
 echo "========== Clone Repository from $GIT_REPOSITORY"

--- a/packs/fetch/build/init.sh
+++ b/packs/fetch/build/init.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 #echo "========= load deployment keys"
 #eval `ssh-agent`
 #ssh-add /root/.ssh/*


### PR DESCRIPTION
Sometime my k8s cluster restart so all the pod restarted, at the time kubero's fetch ran coredns has not been started so git clone failed without terminate the script so the application keep restarting at run due to lack of source code. This addition ensure the script to die with error so the fetcher can be restarted.